### PR TITLE
Prevent exceptions during LifetimeScope resolution in AutofacProcessorFactory

### DIFF
--- a/Jabberwocky.Glass.Autofac.Mvc/Pipelines/Factories/Providers/MvcLifetimeScopeProvider.cs
+++ b/Jabberwocky.Glass.Autofac.Mvc/Pipelines/Factories/Providers/MvcLifetimeScopeProvider.cs
@@ -8,7 +8,14 @@ namespace Jabberwocky.Glass.Autofac.Mvc.Pipelines.Factories.Providers
     {
         public ILifetimeScope GetLifetimeScope()
         {
-            return AutofacDependencyResolver.Current?.RequestLifetimeScope;
+            try
+            {
+                return AutofacDependencyResolver.Current?.RequestLifetimeScope;
+            }
+            catch
+            {
+                return null;
+            }
         }
     }
 }

--- a/Jabberwocky.Glass.Autofac.WebApi/Pipelines/Factories/Providers/WebApiLifetimeScopeProvider.cs
+++ b/Jabberwocky.Glass.Autofac.WebApi/Pipelines/Factories/Providers/WebApiLifetimeScopeProvider.cs
@@ -10,10 +10,17 @@ namespace Jabberwocky.Glass.Autofac.WebApi.Pipelines.Factories.Providers
     {
         public ILifetimeScope GetLifetimeScope()
         {
-            // If using the Autofac.WebApi integration package, this dependency should be of type 'AutofacWebApiDependencyResolver'
-            var resolver = GlobalConfiguration.Configuration.DependencyResolver as IDependencyScope;
+            try
+            {
+                // If using the Autofac.WebApi integration package, this dependency should be of type 'AutofacWebApiDependencyResolver'
+                var resolver = GlobalConfiguration.Configuration.DependencyResolver as IDependencyScope;
 
-            return resolver?.GetRequestLifetimeScope();
+                return resolver?.GetRequestLifetimeScope();
+            }
+            catch
+            {
+                return null;
+            }
         }
     }
 }


### PR DESCRIPTION
If the Dependency Resolver for a given integration (MVC, WebAPI) is configured for the solution, the AutofacProcessorFactory will attempt to resolve child lifetime scopes from those integrations before falling back to the root container.  This functionality is necessary in order to support tagged lifetime scope resolution, such as PerRequest.

However, in the above scenario, if an integration's LifetimeScopeProvider (ex. MvcLifetimeScopeProvider) throws during resolution of the inner lifetime scope, this exception will bubble up and break the AutofacProcessorFactory.

This pull request proposes catching all such exceptions from integrated LifetimeScopeProviders, and falling back to the root Container.
