### PR TITLE
Adding ZIndex property to GlassFactoryTypeAttribute

### DIFF
--- a/Jabberwocky.Glass/Factory/Attributes/GlassFactoryTypeAttribute.cs
+++ b/Jabberwocky.Glass/Factory/Attributes/GlassFactoryTypeAttribute.cs
@@ -11,10 +11,12 @@ namespace Jabberwocky.Glass.Factory.Attributes
 	{
 		public Type Type { get; set; }
 		public bool IsFallback { get; set; }
+		public int ZIndex { get; set; }
 
 		public GlassFactoryTypeAttribute(Type type)
 		{
 			Type = type;
+			ZIndex = 0;
 		}
 	}
 }

--- a/Jabberwocky.Glass/Factory/Builder/Loader/DefaultGlassTypeLoader.cs
+++ b/Jabberwocky.Glass/Factory/Builder/Loader/DefaultGlassTypeLoader.cs
@@ -29,7 +29,8 @@ namespace Jabberwocky.Glass.Factory.Builder.Loader
 			{
 				GlassType = GetGlassType(tuple.Abstract),
 				ImplementationType = tuple.Abstract,
-				IsFallback = GetIsFallback(tuple.Abstract)
+				IsFallback = GetIsFallback(tuple.Abstract),
+				ZIndex = GetZIndex(tuple.Abstract)
 			});
 		}
 
@@ -56,6 +57,12 @@ namespace Jabberwocky.Glass.Factory.Builder.Loader
 		{
 			var customAttribute = abstractType.GetCustomAttribute<GlassFactoryTypeAttribute>(); // overload: true?
 			return customAttribute.Type;
+		}
+
+		protected static int GetZIndex(Type abstractType)
+		{
+			var customAttribute = abstractType.GetCustomAttribute<GlassFactoryTypeAttribute>(); // overload: true?
+			return customAttribute.ZIndex;
 		}
 
 		private static Assembly LoadAssembly(string assemblyName)

--- a/Jabberwocky.Glass/Factory/Util/GlassInterfaceMetadata.cs
+++ b/Jabberwocky.Glass/Factory/Util/GlassInterfaceMetadata.cs
@@ -21,5 +21,11 @@ namespace Jabberwocky.Glass.Factory.Util
 		/// </summary>
 		/// <returns></returns>
 		public bool IsFallback { get; internal set; }
+
+		/// <summary>
+		/// The priority for this abstract implementation type to determine if it will be used when multiple implementations for this GlassType exist.
+		/// </summary>
+		/// <returns></returns>
+		public int ZIndex { get; internal set; }
 	}
 }


### PR DESCRIPTION
Adding ZIndex property to define priority of implementation over other implementations for the same Glass interface.  This is useful for reusable components that use the GlassInterfaceFactory but want to allow for overriding implementations.
