### PR TITLE
Adding check to make sure NewRelic.AppName is not already a valid appsetting.

### DIFF
--- a/src/Extras/Jabberwock.Extras.NewRelic.Sc/Pipelines/Initialize/ApplicationNameProcessor.cs
+++ b/src/Extras/Jabberwock.Extras.NewRelic.Sc/Pipelines/Initialize/ApplicationNameProcessor.cs
@@ -9,6 +9,10 @@ namespace Jabberwocky.Extras.NewRelic.Sc.Pipelines.Initialize
 	{
 		public void Process(PipelineArgs args)
 		{
+			string appSettingsName = Settings.GetAppSetting(Constants.NewRelicAppNameSetting);
+			// If there is an app setting with this name, there is no need for this to run.
+			if (!string.IsNullOrEmpty(appSettingsName)) return;
+
 			string appName = Settings.GetSetting(Constants.NewRelicAppNameSetting);
 
 			if (string.IsNullOrEmpty(appName)) return;


### PR DESCRIPTION
No need for ApplicationNameProcessor to run if appsetting exists.
