### PR TITLE
Interface Segregation: Decomposing IGlassBase

### DIFF
--- a/src/Jabberwocky.Glass.Autofac/Extensions/GlassRegistrationExtensions.cs
+++ b/src/Jabberwocky.Glass.Autofac/Extensions/GlassRegistrationExtensions.cs
@@ -57,7 +57,7 @@ namespace Jabberwocky.Glass.Autofac.Extensions
 				// Register lazy versions of each "DIRECT" (no inheritance) interface
 				foreach (
 					var interfaceType in
-						type.GetInterfaces(false).Where(interfaceType => typeof(IGlassBase).IsAssignableFrom(interfaceType)))
+						type.GetInterfaces(false).Where(interfaceType => typeof(IGlassCore).IsAssignableFrom(interfaceType)))
 				{
 					builder.RegisterType(type).As(interfaceType).ExternallyOwned();
 

--- a/src/Jabberwocky.Glass/Factory/Caching/GlassTemplateCacheService.cs
+++ b/src/Jabberwocky.Glass/Factory/Caching/GlassTemplateCacheService.cs
@@ -46,7 +46,7 @@ namespace Jabberwocky.Glass.Factory.Caching
 			TemplateCache = GenerateCache(interfaceMappings);
 		}
 
-		public Type GetImplementingTypeForItem(IGlassBase item, Type interfaceType)
+		public Type GetImplementingTypeForItem(IGlassCore item, Type interfaceType)
 		{
 			return GetImplementingTypeForTemplate(item._TemplateId, interfaceType);
 		}

--- a/src/Jabberwocky.Glass/Factory/Caching/IGlassTemplateCacheService.cs
+++ b/src/Jabberwocky.Glass/Factory/Caching/IGlassTemplateCacheService.cs
@@ -5,7 +5,7 @@ namespace Jabberwocky.Glass.Factory.Caching
 {
 	public interface IGlassTemplateCacheService
 	{
-		Type GetImplementingTypeForItem(IGlassBase item, Type interfaceType);
+		Type GetImplementingTypeForItem(IGlassCore item, Type interfaceType);
 		Type GetImplementingTypeForTemplate(Guid templateId, Type interfaceType);
 		Type GetFallbackImplementingTypeForTemplate(Guid templateId, Type interfaceType);
 	}

--- a/src/Jabberwocky.Glass/Factory/GlassInterfaceFactory.cs
+++ b/src/Jabberwocky.Glass/Factory/GlassInterfaceFactory.cs
@@ -26,23 +26,23 @@ namespace Jabberwocky.Glass.Factory
 			_factory = factory;
 		}
 
-		public T GetItem<T>(IGlassBase model) where T : class
+		public T GetItem<T>(IGlassCore model) where T : class
 		{
 			var implType = GetItemFromInterface(model, typeof(T));
 
 			return implType != null
-				? _factory.Create<T, IGlassBase>(implType, model)
+				? _factory.Create<T, IGlassCore>(implType, model)
 				: default(T);
 		}
 
-		public IEnumerable<T> GetItems<T>(IEnumerable<IGlassBase> models) where T : class
+		public IEnumerable<T> GetItems<T>(IEnumerable<IGlassCore> models) where T : class
 		{
 			if (models == null) return Enumerable.Empty<T>();
 
 			return models.Select(GetItem<T>).Where(x => x != default(T));
 		}
 
-		private Type GetItemFromInterface(IGlassBase item, Type interfaceType)   // interfaceType: this will be non-generic type, ie. IListable
+		private Type GetItemFromInterface(IGlassCore item, Type interfaceType)   // interfaceType: this will be non-generic type, ie. IListable
 		{
 			if (item == null || interfaceType == null) return null;
 

--- a/src/Jabberwocky.Glass/Factory/IGlassInterfaceFactory.cs
+++ b/src/Jabberwocky.Glass/Factory/IGlassInterfaceFactory.cs
@@ -5,7 +5,7 @@ namespace Jabberwocky.Glass.Factory
 {
 	public interface IGlassInterfaceFactory
 	{
-		T GetItem<T>(IGlassBase model) where T : class;
-		IEnumerable<T> GetItems<T>(IEnumerable<IGlassBase> models) where T : class;
+		T GetItem<T>(IGlassCore model) where T : class;
+		IEnumerable<T> GetItems<T>(IEnumerable<IGlassCore> models) where T : class;
 	}
 }

--- a/src/Jabberwocky.Glass/Factory/Interfaces/BaseInterface.cs
+++ b/src/Jabberwocky.Glass/Factory/Interfaces/BaseInterface.cs
@@ -3,7 +3,7 @@ using Jabberwocky.Glass.Models;
 
 namespace Jabberwocky.Glass.Factory.Interfaces
 {
-	public abstract class BaseInterface<T> where T : class, IGlassBase
+	public abstract class BaseInterface<T> where T : class, IGlassCore
 	{
 		protected virtual T InnerItem { get; private set; }
 

--- a/src/Jabberwocky.Glass/Models/IGlassBase.cs
+++ b/src/Jabberwocky.Glass/Models/IGlassBase.cs
@@ -6,7 +6,24 @@ using Sitecore.Globalization;
 
 namespace Jabberwocky.Glass.Models
 {
-	public interface IGlassBase
+	public interface IGlassBase : IGlassCore, IGlassRelationships<IGlassBase>, IGlassExtendedAttributes
+	{
+		
+	}
+
+	public interface IGlassExtendedAttributes
+	{
+		[SitecoreInfo(SitecoreInfoType.Url)]
+		string _Url { get; set; }
+
+		[SitecoreInfo(SitecoreInfoType.Name)]
+		string _Name { get; set; }
+
+		[SitecoreInfo(SitecoreInfoType.MediaUrl)]
+		string _MediaUrl { get; set; }
+	}
+
+	public interface IGlassCore
 	{
 		[SitecoreId]
 		Guid _Id { get; set; }
@@ -14,31 +31,25 @@ namespace Jabberwocky.Glass.Models
 		[SitecoreInfo(SitecoreInfoType.Language)]
 		Language _Language { get; set; }
 
-		[SitecoreInfo(SitecoreInfoType.Version)]
-		int _Version { get; set; }
-
-		[SitecoreInfo(SitecoreInfoType.Url)]
-		string _Url { get; set; }
-
 		[SitecoreInfo(SitecoreInfoType.TemplateId)]
 		Guid _TemplateId { get; set; }
+
+		[SitecoreInfo(SitecoreInfoType.BaseTemplateIds)]
+		IEnumerable<Guid> _BaseTemplates { get; set; }
 
 		[SitecoreInfo(SitecoreInfoType.Path)]
 		string _Path { get; set; }
 
-		[SitecoreInfo(SitecoreInfoType.Name)]
-		string _Name { get; set; }
+		[SitecoreInfo(SitecoreInfoType.Version)]
+		int _Version { get; set; }
+	}
 
+	public interface IGlassRelationships<T> where T : IGlassCore
+	{
 		[SitecoreChildren(InferType = true, IsLazy = true)]
-		IEnumerable<IGlassBase> _ChildrenWithInferType { get; set; }
+		IEnumerable<T> _ChildrenWithInferType { get; set; }
 
 		[SitecoreParent(InferType = true, IsLazy = true)]
-		IGlassBase _Parent { get; set; }
-
-		[SitecoreInfo(SitecoreInfoType.MediaUrl)]
-		string _MediaUrl { get; set; }
-
-		[SitecoreInfo(SitecoreInfoType.BaseTemplateIds)]
-		IEnumerable<Guid> _BaseTemplates { get; set; }
+		T _Parent { get; set; }
 	}
 }

--- a/src/Jabberwocky.Glass/Models/IGlassBase.cs
+++ b/src/Jabberwocky.Glass/Models/IGlassBase.cs
@@ -21,7 +21,10 @@ namespace Jabberwocky.Glass.Models
 
 		[SitecoreInfo(SitecoreInfoType.MediaUrl)]
 		string _MediaUrl { get; set; }
-	}
+
+        [SitecoreInfo(SitecoreInfoType.BaseTemplateIds)]
+        IEnumerable<Guid> _BaseTemplates { get; set; }
+    }
 
 	public interface IGlassCore
 	{
@@ -33,9 +36,6 @@ namespace Jabberwocky.Glass.Models
 
 		[SitecoreInfo(SitecoreInfoType.TemplateId)]
 		Guid _TemplateId { get; set; }
-
-		[SitecoreInfo(SitecoreInfoType.BaseTemplateIds)]
-		IEnumerable<Guid> _BaseTemplates { get; set; }
 
 		[SitecoreInfo(SitecoreInfoType.Path)]
 		string _Path { get; set; }

--- a/src/Jabberwocky.Glass/Services/IItemService.cs
+++ b/src/Jabberwocky.Glass/Services/IItemService.cs
@@ -5,14 +5,14 @@ namespace Jabberwocky.Glass.Services
 {
 	public interface IItemService
 	{
-		IEnumerable<IGlassBase> GetDescendants(IGlassBase item);
+		IEnumerable<IGlassCore> GetDescendants(IGlassCore item);
 
-		IEnumerable<IGlassBase> GetAncestors(IGlassBase item);
+		IEnumerable<IGlassCore> GetAncestors(IGlassCore item);
 
-		bool HasPresentation(IGlassBase item);
+		bool HasPresentation(IGlassCore item);
 
-		bool IsContentItem(IGlassBase item);
+		bool IsContentItem(IGlassCore item);
 
-		bool IsMediaItem(IGlassBase item);
+		bool IsMediaItem(IGlassCore item);
 	}
 }

--- a/src/Jabberwocky.Glass/Services/ILinkService.cs
+++ b/src/Jabberwocky.Glass/Services/ILinkService.cs
@@ -5,8 +5,8 @@ namespace Jabberwocky.Glass.Services
 {
 	public interface ILinkService
 	{
-		IEnumerable<IGlassBase> GetReferrers(IGlassBase item);
+		IEnumerable<IGlassCore> GetReferrers(IGlassCore item);
 
-		IEnumerable<IGlassBase> GetValidLinkTargets(IGlassBase item);
+		IEnumerable<IGlassCore> GetValidLinkTargets(IGlassCore item);
 	}
 }

--- a/src/Jabberwocky.Glass/Services/ItemService.cs
+++ b/src/Jabberwocky.Glass/Services/ItemService.cs
@@ -17,31 +17,31 @@ namespace Jabberwocky.Glass.Services
 			_service = service;
 		}
 
-		public IEnumerable<IGlassBase> GetDescendants(IGlassBase glassItem)
+		public IEnumerable<IGlassCore> GetDescendants(IGlassCore glassItem)
 		{
 			var item = _service.GetItem<Item>(glassItem._Id, glassItem._Language);
-			return item.Axes.GetDescendants().Select(sItem => _service.GetItem<IGlassBase>(sItem.ID.Guid, inferType: true));
+			return item.Axes.GetDescendants().Select(sItem => _service.GetItem<IGlassCore>(sItem.ID.Guid, inferType: true));
 		}
 
-		public IEnumerable<IGlassBase> GetAncestors(IGlassBase glassItem)
+		public IEnumerable<IGlassCore> GetAncestors(IGlassCore glassItem)
 		{
 			var item = _service.GetItem<Item>(glassItem._Id, glassItem._Language);
-			return item.Axes.GetAncestors().Select(sItem => _service.GetItem<IGlassBase>(sItem.ID.Guid, inferType: true));
+			return item.Axes.GetAncestors().Select(sItem => _service.GetItem<IGlassCore>(sItem.ID.Guid, inferType: true));
 		}
 
-		public bool HasPresentation(IGlassBase glassItem)
+		public bool HasPresentation(IGlassCore glassItem)
 		{
 			var item = _service.GetItem<Item>(glassItem._Id, glassItem._Language);
 			return item != null && item[Sitecore.FieldIDs.LayoutField] != string.Empty;
 		}
 
-		public bool IsContentItem(IGlassBase glassItem)
+		public bool IsContentItem(IGlassCore glassItem)
 		{
 			var item = _service.GetItem<Item>(glassItem._Id, glassItem._Language);
 			return item != null && item.Paths.IsContentItem;
 		}
 
-		public bool IsMediaItem(IGlassBase glassItem)
+		public bool IsMediaItem(IGlassCore glassItem)
 		{
 			var item = _service.GetItem<Item>(glassItem._Id, glassItem._Language);
 			return item != null && item.Paths.IsMediaItem;

--- a/src/Jabberwocky.Glass/Services/LinkService.cs
+++ b/src/Jabberwocky.Glass/Services/LinkService.cs
@@ -18,21 +18,21 @@ namespace Jabberwocky.Glass.Services
 			_service = service;
 		}
 
-		public IEnumerable<IGlassBase> GetReferrers(IGlassBase glassItem)
+		public IEnumerable<IGlassCore> GetReferrers(IGlassCore glassItem)
 		{
 			var item = _service.GetItem<Item>(glassItem._Id, glassItem._Language);
 
 			var links = Globals.LinkDatabase.GetReferrers(item);
-			var linkReferences = links.Select(i => _service.GetItem<IGlassBase>(i.SourceItemID.Guid, i.SourceItemLanguage, inferType: true)).Where(i => i != null);
+			var linkReferences = links.Select(i => _service.GetItem<IGlassCore>(i.SourceItemID.Guid, i.SourceItemLanguage, inferType: true)).Where(i => i != null);
 			return linkReferences;
 		}
 
-		public IEnumerable<IGlassBase> GetValidLinkTargets(IGlassBase glassItem)
+		public IEnumerable<IGlassCore> GetValidLinkTargets(IGlassCore glassItem)
 		{
 			var item = _service.GetItem<Item>(glassItem._Id, glassItem._Language);
 
 			var links = item.Links.GetValidLinks();
-			return links.Select(link => link.GetTargetItem().GlassCast<IGlassBase>(inferType: true));
+			return links.Select(link => link.GetTargetItem().GlassCast<IGlassCore>(inferType: true));
 		}
 	}
 }


### PR DESCRIPTION
This PR contains a refactoring of the IGlassBase/GlassBase models into a composition of multiple sub-models.  The biggest change is the introduction of the IGlassRelationships<T> base model - this allows for specifying the Type of  the 'Parent' and 'Children' properties, allowing for granular extensibility of the base glass model types in the project layer.

For example, if somebody needs to extend the IGlassBase implementation in order to introduce extra base properties that should be exposed on each Sitecore item, they have historically been unable to update the Children and Parent references to use that new base model.  Now however, they can easily do so, as the 'navigation-style' properties have been pushed out into their own generic interface.

Incidentally, all internal references to IGlassBase are now primarily rewritten to use IGlassCore, which contains a very small subset of common properties that can effectively define a unique item.