### PR TITLE
Updating ItemService implementation

### DIFF
--- a/src/Jabberwocky.Glass/Services/ItemService.cs
+++ b/src/Jabberwocky.Glass/Services/ItemService.cs
@@ -20,19 +20,19 @@ namespace Jabberwocky.Glass.Services
 		public IEnumerable<IGlassBase> GetDescendants(IGlassBase glassItem)
 		{
 			var item = _service.GetItem<Item>(glassItem._Id, glassItem._Language);
-			return item.Axes.GetDescendants().Select(sItem => _service.GetItem<IGlassBase>(sItem.ID.Guid, inferType: true));
+			return item.Axes.GetDescendants().Select(sItem => _service.Cast<IGlassBase>(sItem, inferType: true));
 		}
 
 		public IEnumerable<IGlassBase> GetAncestors(IGlassBase glassItem)
 		{
 			var item = _service.GetItem<Item>(glassItem._Id, glassItem._Language);
-			return item.Axes.GetAncestors().Select(sItem => _service.GetItem<IGlassBase>(sItem.ID.Guid, inferType: true));
+			return item.Axes.GetAncestors().Select(sItem => _service.Cast<IGlassBase>(sItem, inferType: true));
 		}
 
 		public bool HasPresentation(IGlassBase glassItem)
 		{
 			var item = _service.GetItem<Item>(glassItem._Id, glassItem._Language);
-			return item != null && item[Sitecore.FieldIDs.LayoutField] != string.Empty;
+			return item != null && item[Sitecore.FieldIDs.FinalLayoutField] != string.Empty;
 		}
 
 		public bool IsContentItem(IGlassBase glassItem)


### PR DESCRIPTION
Using .Cast<>() instead of .GetItem<>() to retrive IGlassbase interface item from Sitecore Item.

HasPresentation now checks against Final Layout field instead of Shared Layout field.  This should be more reliable in determining if an item has presentation assigned.