### PR TITLE
Using Default Language to look up base templates.

### DIFF
--- a/Jabberwocky.Glass/Factory/Caching/GlassTemplateCacheService.cs
+++ b/Jabberwocky.Glass/Factory/Caching/GlassTemplateCacheService.cs
@@ -78,14 +78,17 @@ namespace Jabberwocky.Glass.Factory.Caching
 				// Otherwise, search for match, and update 1st-level cache
 				using (var service = _serviceFactory())
 				{
-					foreach (Guid baseTemplateId in GetBaseTemplates(service.GetItem<IBaseTemplates>(templateId, LanguageManager.DefaultLanguage), service, depth))
-					{
-						string templateIdString = baseTemplateId.ToString();
-						if (itemInterfaces.ContainsKey(templateIdString))
-						{
-							return itemInterfaces[templateIdString].ImplementationType;
-						}
-					}
+				    using (new VersionCountDisabler())
+				    {
+				        foreach (Guid baseTemplateId in GetBaseTemplates(service.GetItem<IBaseTemplates>(templateId), service, depth))
+				        {
+				            string templateIdString = baseTemplateId.ToString();
+				            if (itemInterfaces.ContainsKey(templateIdString))
+				            {
+				                return itemInterfaces[templateIdString].ImplementationType;
+				            }
+				        }
+				    }
 				}
 
 				return null;
@@ -99,14 +102,17 @@ namespace Jabberwocky.Glass.Factory.Caching
 				return null;
 			}
 
-			using (var service = _serviceFactory())
-			{
-				var currentTemplate = service.GetItem<IBaseTemplates>(templateId, LanguageManager.DefaultLanguage);
+		    using (var service = _serviceFactory())
+		    {
+		        using (new VersionCountDisabler())
+		        {
+		            var currentTemplate = service.GetItem<IBaseTemplates>(templateId);
 
-				return GetBaseTemplates(currentTemplate, service, depth: MaxDepth)
-					.Select(guid => InnerGetImplementingTypeForTemplate(guid, interfaceType, 1))
-					.FirstOrDefault(type => type != null);
-			}
+		            return GetBaseTemplates(currentTemplate, service, depth: MaxDepth)
+		                .Select(guid => InnerGetImplementingTypeForTemplate(guid, interfaceType, 1))
+		                .FirstOrDefault(type => type != null);
+		        }
+		    }
 		}
 
 		internal IEnumerable<Guid> GetBaseTemplates(IBaseTemplates item, ISitecoreService service, int depth = DefaultDepth, bool ignoreTemplate = false)

--- a/Jabberwocky.Glass/Factory/Caching/GlassTemplateCacheService.cs
+++ b/Jabberwocky.Glass/Factory/Caching/GlassTemplateCacheService.cs
@@ -75,21 +75,19 @@ namespace Jabberwocky.Glass.Factory.Caching
 			// If no exact match exists, attempt to resolve from 1st-level cache
 			return _firstLevelCache.GetOrAdd(new Tuple<Type, string>(interfaceType, templateKey), key =>
 			{
-				// Otherwise, search for match, and update 1st-level cache
-				using (var service = _serviceFactory())
-				{
-				    using (new VersionCountDisabler())
-				    {
-				        foreach (Guid baseTemplateId in GetBaseTemplates(service.GetItem<IBaseTemplates>(templateId), service, depth))
-				        {
-				            string templateIdString = baseTemplateId.ToString();
-				            if (itemInterfaces.ContainsKey(templateIdString))
-				            {
-				                return itemInterfaces[templateIdString].ImplementationType;
-				            }
-				        }
-				    }
-				}
+                // Otherwise, search for match, and update 1st-level cache
+                using (var service = _serviceFactory())
+                using (new VersionCountDisabler())
+                {
+                    foreach (Guid baseTemplateId in GetBaseTemplates(service.GetItem<IBaseTemplates>(templateId), service, depth))
+                    {
+                        string templateIdString = baseTemplateId.ToString();
+                        if (itemInterfaces.ContainsKey(templateIdString))
+                        {
+                            return itemInterfaces[templateIdString].ImplementationType;
+                        }
+                    }
+                }
 
 				return null;
 			});
@@ -102,17 +100,15 @@ namespace Jabberwocky.Glass.Factory.Caching
 				return null;
 			}
 
-		    using (var service = _serviceFactory())
-		    {
-		        using (new VersionCountDisabler())
-		        {
-		            var currentTemplate = service.GetItem<IBaseTemplates>(templateId);
+            using (var service = _serviceFactory())
+            using (new VersionCountDisabler())
+            {
+                var currentTemplate = service.GetItem<IBaseTemplates>(templateId);
 
-		            return GetBaseTemplates(currentTemplate, service, depth: MaxDepth)
-		                .Select(guid => InnerGetImplementingTypeForTemplate(guid, interfaceType, 1))
-		                .FirstOrDefault(type => type != null);
-		        }
-		    }
+                return GetBaseTemplates(currentTemplate, service, depth: MaxDepth)
+                    .Select(guid => InnerGetImplementingTypeForTemplate(guid, interfaceType, 1))
+                    .FirstOrDefault(type => type != null);
+            }
 		}
 
 		internal IEnumerable<Guid> GetBaseTemplates(IBaseTemplates item, ISitecoreService service, int depth = DefaultDepth, bool ignoreTemplate = false)

--- a/Jabberwocky.Glass/Factory/Caching/GlassTemplateCacheService.cs
+++ b/Jabberwocky.Glass/Factory/Caching/GlassTemplateCacheService.cs
@@ -6,6 +6,7 @@ using Glass.Mapper.Sc;
 using Glass.Mapper.Sc.Configuration.Attributes;
 using Jabberwocky.Glass.Factory.Util;
 using Jabberwocky.Glass.Models;
+using Sitecore.Data.Managers;
 
 namespace Jabberwocky.Glass.Factory.Caching
 {
@@ -77,7 +78,7 @@ namespace Jabberwocky.Glass.Factory.Caching
 				// Otherwise, search for match, and update 1st-level cache
 				using (var service = _serviceFactory())
 				{
-					foreach (Guid baseTemplateId in GetBaseTemplates(service.GetItem<IBaseTemplates>(templateId), service, depth))
+					foreach (Guid baseTemplateId in GetBaseTemplates(service.GetItem<IBaseTemplates>(templateId, LanguageManager.DefaultLanguage), service, depth))
 					{
 						string templateIdString = baseTemplateId.ToString();
 						if (itemInterfaces.ContainsKey(templateIdString))
@@ -100,7 +101,7 @@ namespace Jabberwocky.Glass.Factory.Caching
 
 			using (var service = _serviceFactory())
 			{
-				var currentTemplate = service.GetItem<IBaseTemplates>(templateId);
+				var currentTemplate = service.GetItem<IBaseTemplates>(templateId, LanguageManager.DefaultLanguage);
 
 				return GetBaseTemplates(currentTemplate, service, depth: MaxDepth)
 					.Select(guid => InnerGetImplementingTypeForTemplate(guid, interfaceType, 1))


### PR DESCRIPTION
When using the GlassInterfaceFactory in a non-default language, not all properties were getting mapped properly.  This was because the Base Template lookup was using the current language instead of the Default language.