### PR TITLE
Overriding CacheKey for MiniProfilerRenderer.

### DIFF
--- a/src/Extras/Jabberwocky.Autofac.Extras.MiniProfiler.Sc/Renderer/MiniProfilerRenderer.cs
+++ b/src/Extras/Jabberwocky.Autofac.Extras.MiniProfiler.Sc/Renderer/MiniProfilerRenderer.cs
@@ -19,7 +19,9 @@ namespace Jabberwocky.Autofac.Extras.MiniProfiler.Sc.Renderer
 			_rendering = rendering;
 		}
 
-		public override void Render(TextWriter writer)
+	    public override string CacheKey => _innerRenderer.CacheKey;
+
+	    public override void Render(TextWriter writer)
 		{
 			using (Profiler.Current.Step($"Rendering:{_rendering.RenderingItem?.Name}"))
 			{


### PR DESCRIPTION
Without the override, the CacheKey is null for all Renderings, thus disabling HTML caching.
Passing CacheKey of inner renderer, to preserve HTML caching for these components.