### PR TITLE
Removing custom DynamicPlaceholder method.

### DIFF
--- a/src/Jabberwocky.Glass.Mvc/Util/CustomSitecoreHelper.cs
+++ b/src/Jabberwocky.Glass.Mvc/Util/CustomSitecoreHelper.cs
@@ -64,11 +64,5 @@ namespace Jabberwocky.Glass.Mvc.Util
 
 			return rendering;
 		}
-
-		public virtual HtmlString DynamicPlaceholder(string dynamicKey)
-		{
-			var currentRenderingId = RenderingContext.Current.Rendering.UniqueId;
-			return Placeholder(string.Format("{0}_{1}", dynamicKey, currentRenderingId));
-		}
 	}
 }


### PR DESCRIPTION
Removing the DynamicPlaceholder method in CustomSitecoreHelper since it hides Sitecore's DynamicPlaceholder method.  This is specific to Sitecore v9 as DynamicPlaceholder functionality has been introduced in this version.