### PR TITLE
Fixing Sitecore.Mvc.Exceptions.CyclicRenderingException.

### DIFF
--- a/src/Extras/Jabberwocky.Autofac.Extras.MiniProfiler.Sc/Renderer/MiniProfilerRenderer.cs
+++ b/src/Extras/Jabberwocky.Autofac.Extras.MiniProfiler.Sc/Renderer/MiniProfilerRenderer.cs
@@ -19,14 +19,19 @@ namespace Jabberwocky.Autofac.Extras.MiniProfiler.Sc.Renderer
 			_rendering = rendering;
 		}
 
-	    public override string CacheKey => _innerRenderer.CacheKey;
+		public override string CacheKey => _innerRenderer.CacheKey;
 
-	    public override void Render(TextWriter writer)
+		public override void Render(TextWriter writer)
 		{
 			using (Profiler.Current.Step($"Rendering:{_rendering.RenderingItem?.Name}"))
 			{
 				_innerRenderer.Render(writer);
 			}
+		}
+
+		public override string ToString()
+		{
+			return _innerRenderer.ToString();
 		}
 	}
 }


### PR DESCRIPTION
Sitecore uses the ToString method on the Renderer class to try and detect cyclic renderings.  Since MiniProfilerRenderer wraps the implementing renderer, Sitecore is detecting a cyclic rendering scenario.  This is currently breaking the Forms builder in Sitecore.

To fix, I've overriden the ToString method on MiniProfilerRenderer and returning the ToString value of the inner renderer.